### PR TITLE
add table-borderless class

### DIFF
--- a/includes/table.styl
+++ b/includes/table.styl
@@ -33,6 +33,13 @@
 .table-bordered thead th,
 .table-bordered thead td
     border-bottom-width 2px
+    
+.table-borderless
+    th,
+    td,
+    thead th,
+    tbody + tbody
+        border 0
 
 .table-striped
     tbody


### PR DESCRIPTION
Link to source — https://getbootstrap.com/docs/4.3/content/tables/#borderless-table